### PR TITLE
Fix for issue #28

### DIFF
--- a/Deemixrr/Views/Home/Index.cshtml
+++ b/Deemixrr/Views/Home/Index.cshtml
@@ -76,7 +76,7 @@
                             @{
                                 var bytes = Model.FolderSizeCumulated.Bytes();
                             }
-                            @bytes.LargestWholeNumberValue @bytes.LargestWholeNumberSymbol
+                            @bytes.ToString("#.###")
                         </span>
                     </div>
                 </div>

--- a/Deemixrr/Views/Home/Index.cshtml
+++ b/Deemixrr/Views/Home/Index.cshtml
@@ -76,7 +76,7 @@
                             @{
                                 var bytes = Model.FolderSizeCumulated.Bytes();
                             }
-                            @bytes.ToString("#.###")
+                            @bytes.LargestWholeNumberValue.ToString("#.##") @bytes.LargestWholeNumberSymbol
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Using the ByteSize.ToString("#.###") format, this should present the highest unit and round to 3 decimal places